### PR TITLE
Show error message when no bill is selected

### DIFF
--- a/src/components/OrderList.js
+++ b/src/components/OrderList.js
@@ -100,7 +100,7 @@ const OrderList = () => {
         onChange: onSelectChange,
     };
     const receiveBill = () => {
-        let result;
+        let result = null;
         for (let i = 0; i < selectedRowKeys.length; i++) {
             result = data.find(obj => {
                 return obj.key === selectedRowKeys[i]
@@ -114,6 +114,10 @@ const OrderList = () => {
                 });
             }
 
+        }
+        if (result === null) {
+            message.error('No bill selected!');
+            return
         }
         let dataToPush = {
             timeStamp: result.timeStamp,
@@ -134,13 +138,17 @@ const OrderList = () => {
     }
 
     const billDone = () => {
-        let result;
+        let result = null;
         for (let i = 0; i < selectedRowKeys.length; i++) {
             result = data.find(obj => {
                 return obj.key === selectedRowKeys[i]
             })
             if (result.status === "Processing") result.status = "Done"
             message.success('The bill for table ' + result.key + ' done!');
+        }
+        if (result === null) {
+            message.error('No bill selected!');
+            return
         }
         let dataToPush = {
             timeStamp: result.timeStamp,


### PR DESCRIPTION
This pull request fixes `Uncaught TypeError: Cannot read properties of undefined (reading 'timeStamp')` when no bill is selected and the user clicks "Process selected bills" or "Selected bills done".

**Screenshot of the issue:**

<img width="1390" alt="Screenshot 2023-05-26 at 9 15 08 PM" src="https://github.com/DanielCruise/cashier-coffee-shop-app/assets/18329471/b6d61b80-f51a-4ff0-a08c-182faca062b9">

**After this fix, the app will show the message "No bill selected!" to the user instead of writing the error to the console:**

<img width="1390" alt="Screenshot 2023-05-26 at 9 18 47 PM" src="https://github.com/DanielCruise/cashier-coffee-shop-app/assets/18329471/803fba94-f0f1-4ddd-9092-d8568442afd6">

Please feedback if there is any issue with this pull request. Thank you!

